### PR TITLE
Potential fix for code scanning alert no. 2: Information exposure through an exception

### DIFF
--- a/catalogo/views.py
+++ b/catalogo/views.py
@@ -7,6 +7,7 @@ from django.contrib import messages
 from django.views.decorators.http import require_POST
 from django.core.paginator import Paginator
 import json
+import logging
 
 def home(request):
     """
@@ -431,9 +432,10 @@ def add_review(request, product_slug):
             })
             
         except (ValueError, TypeError) as e:
+            logging.exception("Erro ao processar avaliação do produto.")
             return JsonResponse({
                 'status': 'error',
-                'message': f'Dados inválidos fornecidos. Erro: {str(e)}'
+                'message': 'Dados inválidos fornecidos.'
             })
     
     return JsonResponse({


### PR DESCRIPTION
Potential fix for [https://github.com/23Edu4rd0/OuriPrata/security/code-scanning/2](https://github.com/23Edu4rd0/OuriPrata/security/code-scanning/2)

To correctly address this problem:
- The code should not return the exception message (`str(e)`) within the API response to the user. Instead, it should show a generic error message.
- The details of the exception should be logged server-side for developer/ops visibility.
- This change should be made inside the `except (ValueError, TypeError) as e:` block in the `add_review` function of `catalogo/views.py`.
- To log the exception properly, the Python logging module should be used. It is safe and recommended to add an import for `import logging` at the top of the file if not already present.
- Replace the return message at line 436 with a generic message such as "Dados inválidos fornecidos." and log the detailed exception.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
