### PR TITLE
Potential fix for code scanning alert no. 1: URL redirection from remote source

### DIFF
--- a/accounts/views.py
+++ b/accounts/views.py
@@ -1,6 +1,7 @@
 from django.contrib.auth import authenticate, login as auth_login, logout
 from django.contrib.auth.models import User
 from django.shortcuts import render, redirect
+from django.utils.http import url_has_allowed_host_and_scheme
 from django.contrib import messages
 from .form import SignUpForm
 from .forms import UserProfileForm
@@ -160,7 +161,7 @@ def complete_profile(request):
             
             # Verificar se veio de um checkout
             next_url = request.GET.get('next')
-            if next_url:
+            if next_url and url_has_allowed_host_and_scheme(next_url, allowed_hosts={request.get_host()}):
                 return redirect(next_url)
             
             return redirect('accounts:settings')


### PR DESCRIPTION
Potential fix for [https://github.com/23Edu4rd0/OuriPrata/security/code-scanning/1](https://github.com/23Edu4rd0/OuriPrata/security/code-scanning/1)

The best fix is to validate that the user-supplied `next_url` is a safe URL for redirection. In Django, this is achieved by using the utility function `url_has_allowed_host_and_scheme()` from `django.utils.http`, which checks that the redirect URL refers to a safe location (usually on the same host). 

- In `accounts/views.py`, update the logic for line 164 where `next_url` is used as a redirect target.
- Import `url_has_allowed_host_and_scheme` from `django.utils.http`.
- Before allowing a redirect to `next_url`, check that it is either a safe relative URL or an allowed host.
- If unsafe, fall back to a default (e.g., `'accounts:settings'`).
- No change to existing form or other logic is required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
